### PR TITLE
fix: Ensure tuist adds localizations to main target

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -70,7 +70,8 @@ let project = Project(
             resources: [
                 "SwissTransfer/Resources/LaunchScreen.storyboard",
                 "SwissTransfer/Resources/Assets.xcassets", // Needed for AppIcon and LaunchScreen
-                "SwissTransfer/Resources/PrivacyInfo.xcprivacy"
+                "SwissTransfer/Resources/PrivacyInfo.xcprivacy",
+                "SwissTransfer/Resources/Localizable/**/InfoPlist.strings"
             ],
             entitlements: "SwissTransfer/Resources/SwissTransfer.entitlements",
             scripts: [Constants.swiftlintScript],

--- a/SwissTransfer/Resources/Localizable/de.lproj/InfoPlist.strings
+++ b/SwissTransfer/Resources/Localizable/de.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/*
+ * Loco ios export: iOS InfoPlist.strings
+ * Project: SwissTransfer
+ * Locale: en, English
+ * Tagged: ios-info-plist
+ * Exported by: Ambroise Decouttere
+ * Exported at: Wed, 24 Jul 2024 08:51:19 +0200
+ */

--- a/SwissTransfer/Resources/Localizable/en.lproj/InfoPlist.strings
+++ b/SwissTransfer/Resources/Localizable/en.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/*
+ * Loco ios export: iOS InfoPlist.strings
+ * Project: SwissTransfer
+ * Locale: en, English
+ * Tagged: ios-info-plist
+ * Exported by: Ambroise Decouttere
+ * Exported at: Wed, 24 Jul 2024 08:51:19 +0200
+ */

--- a/SwissTransfer/Resources/Localizable/es.lproj/InfoPlist.strings
+++ b/SwissTransfer/Resources/Localizable/es.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/*
+ * Loco ios export: iOS InfoPlist.strings
+ * Project: SwissTransfer
+ * Locale: en, English
+ * Tagged: ios-info-plist
+ * Exported by: Ambroise Decouttere
+ * Exported at: Wed, 24 Jul 2024 08:51:19 +0200
+ */

--- a/SwissTransfer/Resources/Localizable/fr.lproj/InfoPlist.strings
+++ b/SwissTransfer/Resources/Localizable/fr.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/*
+ * Loco ios export: iOS InfoPlist.strings
+ * Project: SwissTransfer
+ * Locale: en, English
+ * Tagged: ios-info-plist
+ * Exported by: Ambroise Decouttere
+ * Exported at: Wed, 24 Jul 2024 08:51:19 +0200
+ */

--- a/SwissTransfer/Resources/Localizable/it.lproj/InfoPlist.strings
+++ b/SwissTransfer/Resources/Localizable/it.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/*
+ * Loco ios export: iOS InfoPlist.strings
+ * Project: SwissTransfer
+ * Locale: en, English
+ * Tagged: ios-info-plist
+ * Exported by: Ambroise Decouttere
+ * Exported at: Wed, 24 Jul 2024 08:51:19 +0200
+ */


### PR DESCRIPTION
Tuist needs at least one localizable file in the main target to correctly advertise localizations to the Xcode project.
For now InfoPlist.strings is empty.