### PR TITLE
feat: Sendable upload objects

### DIFF
--- a/SwissTransferFeatures/UploadProgressView/TransferSessionManager.swift
+++ b/SwissTransferFeatures/UploadProgressView/TransferSessionManager.swift
@@ -78,15 +78,11 @@ class TransferSessionManager: ObservableObject {
 
         let uploadManager = injection.uploadManager
 
-        let uploadSession = try await uploadManager.createAndGetUpload(newUploadSession: newUploadSession)
+        let uploadSession = try await uploadManager.createAndGetSendableUploadSession(newUploadSession: newUploadSession)
 
-        let uploadWithRemoteContainer = try await uploadManager.doInitUploadSession(
-            uuid: uploadSession.uuid,
-            recaptcha: "aabb"
-        )
+        let uploadWithRemoteContainer = try await uploadManager.initSendableUploadSession(uuid: uploadSession.uuid)
 
-        guard let uploadWithRemoteContainer,
-              let container = uploadWithRemoteContainer.remoteContainer else {
+        guard let uploadWithRemoteContainer else {
             throw ErrorDomain.remoteContainerNotFound
         }
 
@@ -104,8 +100,6 @@ class TransferSessionManager: ObservableObject {
                     uploadUUID: uploadSession.uuid
                 )
             }
-
-        Logger.general.info("Found container: \(container.uuid)")
 
         let transferUUID = try await uploadManager.finishUploadSession(uuid: uploadSession.uuid)
 


### PR DESCRIPTION
Some objects returned by KMP are not Sendable because they return a protocol. 
This objects are wrapped inside simple Sendable structs until we have a better Swift interop.