### PR TITLE
chore: Update networkUnavailable string

### DIFF
--- a/SwissTransferResources/Localizable/de.lproj/Localizable.strings
+++ b/SwissTransferResources/Localizable/de.lproj/Localizable.strings
@@ -10,6 +10,9 @@
 /* loco:6707f4ba182e2d63b400cd42 */
 "advancedSettingsTitle" = "Erweiterte Einstellungen";
 
+/* loco:677be58b7579b67f0406b33e */
+"awaitingNetwork" = "Auf Netzwerk warten";
+
 /* loco:66bf172f88dce506ed0a5ce2 */
 "buttonAddFiles" = "Dateien hinzufügen";
 
@@ -107,7 +110,7 @@
 "myFilesTitle" = "Meine Dateien";
 
 /* loco:673b609c03c82748a509bd92 */
-"networkUnavailable" = "Auf Netzwerk warten";
+"networkUnavailable" = "Netzwerk nicht verfügbar";
 
 /* loco:66e980bf4e282a19d208a9b2 */
 "noFileDescription" = "Fügt bis zu 50 GB an Dateien hinzu";

--- a/SwissTransferResources/Localizable/en.lproj/Localizable.strings
+++ b/SwissTransferResources/Localizable/en.lproj/Localizable.strings
@@ -10,6 +10,9 @@
 /* loco:6707f4ba182e2d63b400cd42 */
 "advancedSettingsTitle" = "Advanced settings";
 
+/* loco:677be58b7579b67f0406b33e */
+"awaitingNetwork" = "Waiting for network";
+
 /* loco:66bf172f88dce506ed0a5ce2 */
 "buttonAddFiles" = "Add files";
 
@@ -104,7 +107,7 @@
 "myFilesTitle" = "My files";
 
 /* loco:673b609c03c82748a509bd92 */
-"networkUnavailable" = "Waiting for network";
+"networkUnavailable" = "Network unavailable";
 
 /* loco:66e980bf4e282a19d208a9b2 */
 "noFileDescription" = "Add up to 50 GB of files";

--- a/SwissTransferResources/Localizable/es.lproj/Localizable.strings
+++ b/SwissTransferResources/Localizable/es.lproj/Localizable.strings
@@ -10,6 +10,9 @@
 /* loco:6707f4ba182e2d63b400cd42 */
 "advancedSettingsTitle" = "Ajustes avanzados";
 
+/* loco:677be58b7579b67f0406b33e */
+"awaitingNetwork" = "Esperando la red";
+
 /* loco:66bf172f88dce506ed0a5ce2 */
 "buttonAddFiles" = "Añadir archivos";
 
@@ -105,7 +108,7 @@
 "myFilesTitle" = "Mis archivos";
 
 /* loco:673b609c03c82748a509bd92 */
-"networkUnavailable" = "Esperando la red";
+"networkUnavailable" = "Red no disponible";
 
 /* loco:66e980bf4e282a19d208a9b2 */
 "noFileDescription" = "Añade hasta 50 GB de archivos";

--- a/SwissTransferResources/Localizable/fr.lproj/Localizable.strings
+++ b/SwissTransferResources/Localizable/fr.lproj/Localizable.strings
@@ -10,6 +10,9 @@
 /* loco:6707f4ba182e2d63b400cd42 */
 "advancedSettingsTitle" = "Paramètres avancés";
 
+/* loco:677be58b7579b67f0406b33e */
+"awaitingNetwork" = "En attente de réseau";
+
 /* loco:66bf172f88dce506ed0a5ce2 */
 "buttonAddFiles" = "Ajouter des fichiers";
 
@@ -104,7 +107,7 @@
 "myFilesTitle" = "Mes fichiers";
 
 /* loco:673b609c03c82748a509bd92 */
-"networkUnavailable" = "En attente de réseau";
+"networkUnavailable" = "Réseau indisponible";
 
 /* loco:66e980bf4e282a19d208a9b2 */
 "noFileDescription" = "Ajoute jusqu’à 50 Go de fichiers";

--- a/SwissTransferResources/Localizable/it.lproj/Localizable.strings
+++ b/SwissTransferResources/Localizable/it.lproj/Localizable.strings
@@ -10,6 +10,9 @@
 /* loco:6707f4ba182e2d63b400cd42 */
 "advancedSettingsTitle" = "Impostazioni avanzate";
 
+/* loco:677be58b7579b67f0406b33e */
+"awaitingNetwork" = "In attesa della rete";
+
 /* loco:66bf172f88dce506ed0a5ce2 */
 "buttonAddFiles" = "Aggiunta di file";
 
@@ -104,7 +107,7 @@
 "myFilesTitle" = "I miei file";
 
 /* loco:673b609c03c82748a509bd92 */
-"networkUnavailable" = "In attesa della rete";
+"networkUnavailable" = "Rete non disponibile";
 
 /* loco:66e980bf4e282a19d208a9b2 */
 "noFileDescription" = "Aggiungere fino a 50 GB di file";


### PR DESCRIPTION
- `networkUnavailable` become `awaitingNetwork`
- New string `networkUnavailable`

We still use `networkUnavailable` on iOS, even if the string has changed, because it's more accurate