### PR TITLE
feat: KMP errors and breadcrumbs hooked to Sentry

### DIFF
--- a/SwissTransferCore/Sentry/CrashLevelWrapper.swift
+++ b/SwissTransferCore/Sentry/CrashLevelWrapper.swift
@@ -1,0 +1,40 @@
+/*
+ Infomaniak SwissTransfer - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import Sentry
+import STCore
+
+public struct CrashLevelWrapper {
+    init(crashReportLevel: STCore.CrashReportLevel) {
+        switch crashReportLevel {
+        case .debug:
+            sentryLevel = .debug
+        case .info:
+            sentryLevel = .info
+        case .warning:
+            sentryLevel = .warning
+        case .error:
+            sentryLevel = .error
+        case .fatal:
+            sentryLevel = .fatal
+        }
+    }
+
+    let sentryLevel: SentryLevel
+}

--- a/SwissTransferCore/Sentry/CrashReportLevel+Sentry.swift
+++ b/SwissTransferCore/Sentry/CrashReportLevel+Sentry.swift
@@ -20,21 +20,19 @@ import Foundation
 import Sentry
 import STCore
 
-public struct CrashLevelWrapper {
-    init(crashReportLevel: STCore.CrashReportLevel) {
-        switch crashReportLevel {
+public extension STCore.CrashReportLevel {
+    var sentryLevel: SentryLevel {
+        switch self {
         case .debug:
-            sentryLevel = .debug
+            return .debug
         case .info:
-            sentryLevel = .info
+            return .info
         case .warning:
-            sentryLevel = .warning
+            return .warning
         case .error:
-            sentryLevel = .error
+            return .error
         case .fatal:
-            sentryLevel = .fatal
+            return .fatal
         }
     }
-
-    let sentryLevel: SentryLevel
 }

--- a/SwissTransferCore/Sentry/KotlinThrowableWrapper.swift
+++ b/SwissTransferCore/Sentry/KotlinThrowableWrapper.swift
@@ -1,0 +1,41 @@
+/*
+ Infomaniak SwissTransfer - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import Sentry
+import STCore
+
+public final class KotlinThrowableWrapper: NSError, @unchecked Sendable {
+    public init(kotlinThrowable: KotlinThrowable) {
+        let errorMessage = kotlinThrowable.message ?? ""
+        let userInfo: [String: Any]
+        if let cause = kotlinThrowable.cause {
+            let underlyingError = [KotlinThrowableWrapper(kotlinThrowable: cause)]
+            userInfo = [NSLocalizedDescriptionKey: errorMessage, NSUnderlyingErrorKey: underlyingError]
+        } else {
+            userInfo = [NSLocalizedDescriptionKey: errorMessage]
+        }
+
+        super.init(domain: "kmp.infomaniak.com", code: -666, userInfo: userInfo)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/SwissTransferCore/Sentry/SentryKMPWrapper.swift
+++ b/SwissTransferCore/Sentry/SentryKMPWrapper.swift
@@ -31,7 +31,7 @@ public final class SentryKMPWrapper: CrashReportInterface {
         }
     }
 
-    public func capture(error: KotlinThrowable, context: [String: Any]?, contextKey: String?) {
+    public func capture(error: KotlinThrowable, data context: [String: Any]?, category contextKey: String?) {
         Task {
             let errorWrapper = KotlinThrowableWrapper(kotlinThrowable: error)
             SentrySDK.capture(error: errorWrapper) { scope in
@@ -44,8 +44,8 @@ public final class SentryKMPWrapper: CrashReportInterface {
 
     public func capture(
         message: String,
-        context: [String: Any]?,
-        contextKey: String?,
+        data context: [String: Any]?,
+        category contextKey: String?,
         level: STCore.CrashReportLevel?
     ) {
         Task {

--- a/SwissTransferCore/Sentry/SentryKMPWrapper.swift
+++ b/SwissTransferCore/Sentry/SentryKMPWrapper.swift
@@ -20,45 +20,6 @@ import Foundation
 import Sentry
 import STCore
 
-public struct CrashLevelWrapper {
-    init(crashReportLevel: STCore.CrashReportLevel) {
-        switch crashReportLevel {
-        case .debug:
-            sentryLevel = .debug
-        case .info:
-            sentryLevel = .info
-        case .warning:
-            sentryLevel = .warning
-        case .error:
-            sentryLevel = .error
-        case .fatal:
-            sentryLevel = .fatal
-        }
-    }
-
-    let sentryLevel: SentryLevel
-}
-
-public final class KotlinThrowableWrapper: NSError, @unchecked Sendable {
-    public init(kotlinThrowable: KotlinThrowable) {
-        let errorMessage = kotlinThrowable.message ?? ""
-        let userInfo: [String: Any]
-        if let cause = kotlinThrowable.cause {
-            let underlyingError = [KotlinThrowableWrapper(kotlinThrowable: cause)]
-            userInfo = [NSLocalizedDescriptionKey: errorMessage, NSUnderlyingErrorKey: underlyingError]
-        } else {
-            userInfo = [NSLocalizedDescriptionKey: errorMessage]
-        }
-
-        super.init(domain: "kmp.infomaniak.com", code: -666, userInfo: userInfo)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
-
 public final class SentryKMPWrapper: CrashReportInterface {
     public func addBreadcrumb(message: String, category: String, level: STCore.CrashReportLevel, metadata: [String: Any]?) {
         Task {

--- a/SwissTransferCore/Sentry/SentryKMPWrapper.swift
+++ b/SwissTransferCore/Sentry/SentryKMPWrapper.swift
@@ -21,26 +21,22 @@ import Sentry
 import STCore
 
 public final class SentryKMPWrapper: CrashReportInterface {
-    public func addBreadcrumb(message: String, category: String, level: STCore.CrashReportLevel, metadata: [String: Any]?) {
+    public func addBreadcrumb(message: String, category: String, level: STCore.CrashReportLevel, data: [String: Any]?) {
         Task {
             let sentryLevel = CrashLevelWrapper(crashReportLevel: level).sentryLevel
             let breadcrumb = Breadcrumb(level: sentryLevel, category: category)
             breadcrumb.message = message
-            breadcrumb.data = metadata
+            breadcrumb.data = data
             SentrySDK.addBreadcrumb(breadcrumb)
         }
     }
 
-    public func capture(error: KotlinThrowable, context: [String: Any]?, contextKey: String?, extras: [String: Any]?) {
+    public func capture(error: KotlinThrowable, context: [String: Any]?, contextKey: String?) {
         Task {
             let errorWrapper = KotlinThrowableWrapper(kotlinThrowable: error)
             SentrySDK.capture(error: errorWrapper) { scope in
                 if let context, let contextKey {
                     scope.setContext(value: context, key: contextKey)
-                }
-
-                if let extras {
-                    scope.setExtras(extras)
                 }
             }
         }
@@ -50,8 +46,7 @@ public final class SentryKMPWrapper: CrashReportInterface {
         message: String,
         context: [String: Any]?,
         contextKey: String?,
-        level: STCore.CrashReportLevel?,
-        extras: [String: Any]?
+        level: STCore.CrashReportLevel?
     ) {
         Task {
             SentrySDK.capture(message: message) { scope in
@@ -62,10 +57,6 @@ public final class SentryKMPWrapper: CrashReportInterface {
                 if let level {
                     let sentryLevel = CrashLevelWrapper(crashReportLevel: level).sentryLevel
                     scope.setLevel(sentryLevel)
-                }
-
-                if let extras {
-                    scope.setExtras(extras)
                 }
             }
         }

--- a/SwissTransferCore/Sentry/SentryKMPWrapper.swift
+++ b/SwissTransferCore/Sentry/SentryKMPWrapper.swift
@@ -1,0 +1,112 @@
+/*
+ Infomaniak SwissTransfer - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import Sentry
+import STCore
+
+public struct CrashLevelWrapper {
+    init(crashReportLevel: STCore.CrashReportLevel) {
+        switch crashReportLevel {
+        case .debug:
+            sentryLevel = .debug
+        case .info:
+            sentryLevel = .info
+        case .warning:
+            sentryLevel = .warning
+        case .error:
+            sentryLevel = .error
+        case .fatal:
+            sentryLevel = .fatal
+        }
+    }
+
+    let sentryLevel: SentryLevel
+}
+
+public final class KotlinThrowableWrapper: NSError, @unchecked Sendable {
+    public init(kotlinThrowable: KotlinThrowable) {
+        let errorMessage = kotlinThrowable.message ?? ""
+        let userInfo: [String: Any]
+        if let cause = kotlinThrowable.cause {
+            let underlyingError = [KotlinThrowableWrapper(kotlinThrowable: cause)]
+            userInfo = [NSLocalizedDescriptionKey: errorMessage, NSUnderlyingErrorKey: underlyingError]
+        } else {
+            userInfo = [NSLocalizedDescriptionKey: errorMessage]
+        }
+
+        super.init(domain: "kmp.infomaniak.com", code: -666, userInfo: userInfo)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+public final class SentryKMPWrapper: CrashReportInterface {
+    public func addBreadcrumb(message: String, category: String, level: STCore.CrashReportLevel, metadata: [String: Any]?) {
+        Task {
+            let sentryLevel = CrashLevelWrapper(crashReportLevel: level).sentryLevel
+            let breadcrumb = Breadcrumb(level: sentryLevel, category: category)
+            breadcrumb.message = message
+            breadcrumb.data = metadata
+            SentrySDK.addBreadcrumb(breadcrumb)
+        }
+    }
+
+    public func capture(error: KotlinThrowable, context: [String: Any]?, contextKey: String?, extras: [String: Any]?) {
+        Task {
+            let errorWrapper = KotlinThrowableWrapper(kotlinThrowable: error)
+            SentrySDK.capture(error: errorWrapper) { scope in
+                if let context, let contextKey {
+                    scope.setContext(value: context, key: contextKey)
+                }
+
+                if let extras {
+                    scope.setExtras(extras)
+                }
+            }
+        }
+    }
+
+    public func capture(
+        message: String,
+        context: [String: Any]?,
+        contextKey: String?,
+        level: STCore.CrashReportLevel?,
+        extras: [String: Any]?
+    ) {
+        Task {
+            SentrySDK.capture(message: message) { scope in
+                if let context, let contextKey {
+                    scope.setContext(value: context, key: contextKey)
+                }
+
+                if let level {
+                    let sentryLevel = CrashLevelWrapper(crashReportLevel: level).sentryLevel
+                    scope.setLevel(sentryLevel)
+                }
+
+                if let extras {
+                    scope.setExtras(extras)
+                }
+            }
+        }
+    }
+}

--- a/SwissTransferCore/Sentry/SentryKMPWrapper.swift
+++ b/SwissTransferCore/Sentry/SentryKMPWrapper.swift
@@ -22,22 +22,18 @@ import STCore
 
 public final class SentryKMPWrapper: CrashReportInterface {
     public func addBreadcrumb(message: String, category: String, level: STCore.CrashReportLevel, data: [String: Any]?) {
-        Task {
-            let sentryLevel = CrashLevelWrapper(crashReportLevel: level).sentryLevel
-            let breadcrumb = Breadcrumb(level: sentryLevel, category: category)
-            breadcrumb.message = message
-            breadcrumb.data = data
-            SentrySDK.addBreadcrumb(breadcrumb)
-        }
+        let sentryLevel = CrashLevelWrapper(crashReportLevel: level).sentryLevel
+        let breadcrumb = Breadcrumb(level: sentryLevel, category: category)
+        breadcrumb.message = message
+        breadcrumb.data = data
+        SentrySDK.addBreadcrumb(breadcrumb)
     }
 
     public func capture(error: KotlinThrowable, data context: [String: Any]?, category contextKey: String?) {
-        Task {
-            let errorWrapper = KotlinThrowableWrapper(kotlinThrowable: error)
-            SentrySDK.capture(error: errorWrapper) { scope in
-                if let context, let contextKey {
-                    scope.setContext(value: context, key: contextKey)
-                }
+        let errorWrapper = KotlinThrowableWrapper(kotlinThrowable: error)
+        SentrySDK.capture(error: errorWrapper) { scope in
+            if let context, let contextKey {
+                scope.setContext(value: context, key: contextKey)
             }
         }
     }
@@ -48,16 +44,14 @@ public final class SentryKMPWrapper: CrashReportInterface {
         category contextKey: String?,
         level: STCore.CrashReportLevel?
     ) {
-        Task {
-            SentrySDK.capture(message: message) { scope in
-                if let context, let contextKey {
-                    scope.setContext(value: context, key: contextKey)
-                }
+        SentrySDK.capture(message: message) { scope in
+            if let context, let contextKey {
+                scope.setContext(value: context, key: contextKey)
+            }
 
-                if let level {
-                    let sentryLevel = CrashLevelWrapper(crashReportLevel: level).sentryLevel
-                    scope.setLevel(sentryLevel)
-                }
+            if let level {
+                let sentryLevel = CrashLevelWrapper(crashReportLevel: level).sentryLevel
+                scope.setLevel(sentryLevel)
             }
         }
     }

--- a/SwissTransferCore/Sentry/SentryKMPWrapper.swift
+++ b/SwissTransferCore/Sentry/SentryKMPWrapper.swift
@@ -22,8 +22,7 @@ import STCore
 
 public final class SentryKMPWrapper: CrashReportInterface {
     public func addBreadcrumb(message: String, category: String, level: STCore.CrashReportLevel, data: [String: Any]?) {
-        let sentryLevel = CrashLevelWrapper(crashReportLevel: level).sentryLevel
-        let breadcrumb = Breadcrumb(level: sentryLevel, category: category)
+        let breadcrumb = Breadcrumb(level: level.sentryLevel, category: category)
         breadcrumb.message = message
         breadcrumb.data = data
         SentrySDK.addBreadcrumb(breadcrumb)
@@ -50,8 +49,7 @@ public final class SentryKMPWrapper: CrashReportInterface {
             }
 
             if let level {
-                let sentryLevel = CrashLevelWrapper(crashReportLevel: level).sentryLevel
-                scope.setLevel(sentryLevel)
+                scope.setLevel(level.sentryLevel)
             }
         }
     }

--- a/SwissTransferCore/TargetAssembly.swift
+++ b/SwissTransferCore/TargetAssembly.swift
@@ -62,6 +62,8 @@ open class TargetAssembly {
                                                              factoryParameters: nil,
                                                              resolver: resolver)
 
+                let sentryWrapper = SentryKMPWrapper()
+
                 let realmRootDirectory = groupPathProvider.realmRootURL.path()
                 Logger.general.info("Realm group directory \(realmRootDirectory)")
 
@@ -69,13 +71,15 @@ open class TargetAssembly {
                 return SwissTransferInjection(
                     environment: STCore.ApiEnvironment.Preprod(),
                     userAgent: UserAgentBuilder().userAgent,
-                    databaseRootDirectory: realmRootDirectory
+                    databaseRootDirectory: realmRootDirectory,
+                    crashReport: sentryWrapper
                 )
                 #else
                 return SwissTransferInjection(
                     environment: STCore.ApiEnvironment.Prod(),
                     userAgent: UserAgentBuilder().userAgent,
-                    databaseRootDirectory: realmRootDirectory
+                    databaseRootDirectory: realmRootDirectory,
+                    crashReport: sentryWrapper
                 )
                 #endif
             },

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/multiplatform-SwissTransfer",
       "state" : {
-        "revision" : "6de9175d5778e331d247877b27865defd0e55888",
-        "version" : "3.1.0"
+        "revision" : "e1117c6990429c9302931754c0103eb6dc114728",
+        "version" : "4.0.0"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "18.6.0")),
         .package(url: "https://github.com/Infomaniak/ios-onboarding", .upToNextMajor(from: "1.1.2")),
         .package(url: "https://github.com/Infomaniak/ios-device-check", .upToNextMajor(from: "1.1.0")),
-        .package(url: "https://github.com/Infomaniak/multiplatform-SwissTransfer", .upToNextMajor(from: "3.0.0")),
+        .package(url: "https://github.com/Infomaniak/multiplatform-SwissTransfer", .upToNextMajor(from: "4.0.0")),
         .package(url: "https://github.com/Infomaniak/swift-concurrency", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/Infomaniak/swift-modal-presentation", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/getsentry/sentry-cocoa", .upToNextMajor(from: "8.0.0")),


### PR DESCRIPTION
### Abstract 

An error reporting interface was built KMP side.

This PR aims at hooking the KMP error reporting interface to the existing Sentry.

Some minor adaptation work was required to make `KotlinThrowable` work well with `NSError` APIs.

Depends on https://github.com/Infomaniak/multiplatform-SwissTransfer/pull/202

Android sister PR https://github.com/Infomaniak/android-SwissTransfer/pull/484