### PR TITLE
fix: Invert QR and Download button for received transfer

### DIFF
--- a/SwissTransferCoreUI/Components/DownloadButton.swift
+++ b/SwissTransferCoreUI/Components/DownloadButton.swift
@@ -45,20 +45,33 @@ public struct DownloadButton: View {
     @State private var downloadedTransferURL: IdentifiableURL?
 
     let transfer: TransferUi
+    let vertical: Bool
 
-    public init(transfer: TransferUi) {
+    public init(transfer: TransferUi, vertical: Bool = false) {
         self.transfer = transfer
+        self.vertical = vertical
     }
 
     public var body: some View {
         Button(action: startOrCancelDownloadIfNeeded) {
-            Label(
-                title: {
+            if vertical {
+                VStack {
+                    STResourcesAsset.Images.arrowDownLine.swiftUIImage
+                        .iconSize(.large)
+
                     Text(STResourcesStrings.Localizable.buttonDownload)
-                },
-                icon: { STResourcesAsset.Images.arrowDownLine.swiftUIImage }
-            )
-            .labelStyle(.iconOnly)
+                        .font(.ST.caption)
+                }
+                .frame(width: 100)
+            } else {
+                Label(
+                    title: {
+                        Text(STResourcesStrings.Localizable.buttonDownload)
+                    },
+                    icon: { STResourcesAsset.Images.arrowDownLine.swiftUIImage }
+                )
+                .labelStyle(.iconOnly)
+            }
         }
         .downloadProgressAlertFor(transfer: transfer) { downloadedFileURL in
             self.downloadedTransferURL = IdentifiableURL(url: downloadedFileURL)

--- a/SwissTransferFeatures/TransferDetailsView/ShareTransferModifier.swift
+++ b/SwissTransferFeatures/TransferDetailsView/ShareTransferModifier.swift
@@ -20,12 +20,12 @@ import InfomaniakDI
 import STCore
 import STResources
 import SwiftUI
+import SwissTransferCoreUI
 
 struct ShareTransferModifier: ViewModifier {
     @LazyInjectService private var injection: SwissTransferInjection
     let transfer: TransferUi
 
-    @State private var isShowingQRCode = false
     @State private var isShowingPassword = false
 
     private var transferURL: URL? {
@@ -53,22 +53,12 @@ struct ShareTransferModifier: ViewModifier {
                         }
 
                         Spacer()
+                    }
 
-                        Button {
-                            isShowingQRCode = true
-                        } label: {
-                            VStack {
-                                STResourcesAsset.Images.qrCode.swiftUIImage
-                                    .iconSize(.large)
-
-                                Text(STResourcesStrings.Localizable.transferTypeQrCode)
-                                    .font(.ST.caption)
-                            }
-                            .frame(width: 100)
-                        }
-                        .floatingPanel(isPresented: $isShowingQRCode, bottomPadding: .zero) {
-                            QRCodePanelView(url: transferURL)
-                        }
+                    if transfer.direction == .sent {
+                        QRCodePanelButton(transfer: transfer, vertical: true)
+                    } else {
+                        DownloadButton(transfer: transfer, vertical: true)
                     }
 
                     Spacer()

--- a/SwissTransferFeatures/TransferDetailsView/TransferDetails/QRCodePanelButton.swift
+++ b/SwissTransferFeatures/TransferDetailsView/TransferDetails/QRCodePanelButton.swift
@@ -1,0 +1,66 @@
+/*
+ Infomaniak SwissTransfer - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import InfomaniakDI
+import STCore
+import STResources
+import SwiftUI
+
+struct QRCodePanelButton: View {
+    @LazyInjectService var injection: SwissTransferInjection
+    @State private var isShowingQRCode = false
+
+    let transfer: TransferUi
+    let vertical: Bool
+
+    private var transferURL: URL? {
+        let apiURLCreator = injection.sharedApiUrlCreator
+        let url = apiURLCreator.shareTransferUrl(transferUUID: transfer.uuid)
+        return URL(string: url)
+    }
+
+    var body: some View {
+        if let transferURL {
+            Button {
+                isShowingQRCode = true
+            } label: {
+                if vertical {
+                    VStack {
+                        STResourcesAsset.Images.qrCode.swiftUIImage
+                            .iconSize(.large)
+
+                        Text(STResourcesStrings.Localizable.transferTypeQrCode)
+                            .font(.ST.caption)
+                    }
+                    .frame(width: 100)
+                } else {
+                    Label {
+                        Text(STResourcesStrings.Localizable.transferTypeQrCode)
+                            .font(.ST.caption)
+                    } icon: {
+                        STResourcesAsset.Images.qrCode.swiftUIImage
+                            .iconSize(.large)
+                    }
+                }
+            }
+            .floatingPanel(isPresented: $isShowingQRCode, bottomPadding: .zero) {
+                QRCodePanelView(url: transferURL)
+            }
+        }
+    }
+}

--- a/SwissTransferFeatures/TransferDetailsView/TransferDetails/TransferDetailsView.swift
+++ b/SwissTransferFeatures/TransferDetailsView/TransferDetails/TransferDetailsView.swift
@@ -81,7 +81,11 @@ public struct TransferDetailsView: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 if let transfer {
-                    DownloadButton(transfer: transfer)
+                    if transfer.direction == .sent {
+                        DownloadButton(transfer: transfer)
+                    } else {
+                        QRCodePanelButton(transfer: transfer, vertical: false)
+                    }
                 }
             }
         }


### PR DESCRIPTION
A small PR to reverse the download button and the button that displays the QR code in the details view of a received transfer, for greater convenience.