### PR TITLE
refactor: Move matomo view extension to core ui

### DIFF
--- a/SwissTransferCore/MatomoUtils+Extension.swift
+++ b/SwissTransferCore/MatomoUtils+Extension.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import InfomaniakCoreCommonUI
-import InfomaniakDI
 import STCore
 import SwiftUI
 
@@ -33,25 +32,8 @@ public extension MatomoUtils {
 
 // MARK: - Track views
 
-struct MatomoView: ViewModifier {
-    @LazyInjectService var matomo: MatomoUtils
-
-    let path: [String]
-
-    init(view: MatomoScreen) {
-        path = [view.value]
-    }
-
-    func body(content: Content) -> some View {
-        content
-            .onAppear {
-                matomo.track(view: path)
-            }
-    }
-}
-
 public extension View {
     func matomoView(view: MatomoScreen) -> some View {
-        modifier(MatomoView(view: view))
+        modifier(MatomoView(view: [view.value]))
     }
 }

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core-ui",
       "state" : {
-        "revision" : "b3570c1c906e605cb9a798deef1081a42ef6636f",
-        "version" : "19.5.0"
+        "revision" : "b1d5907d4e990f6f203db6d0287dc11c6ff543a3",
+        "version" : "19.6.0"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     name: "SwissTransfer",
     dependencies: [
         .package(url: "https://github.com/Infomaniak/ios-core", .upToNextMajor(from: "15.3.0")),
-        .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "19.4.0")),
+        .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "19.6.0")),
         .package(url: "https://github.com/Infomaniak/ios-onboarding", .upToNextMajor(from: "1.1.2")),
         .package(url: "https://github.com/Infomaniak/ios-device-check", .upToNextMajor(from: "1.1.0")),
         .package(url: "https://github.com/Infomaniak/multiplatform-SwissTransfer", .upToNextMajor(from: "5.3.3")),


### PR DESCRIPTION
Depends on https://github.com/Infomaniak/ios-core-ui/pull/107